### PR TITLE
Add support for retrieving `Contribute` from README

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,14 @@
     "git-remote-origin-url": "^2.0.0",
     "git-remote-upstream-url": "^2.0.0",
     "json-diff": "^0.5.2",
+    "mdast-util-heading-range": "^2.1.0",
     "meow": "^3.7.0",
     "mz": "^2.7.0",
-    "querystring": "^0.2.0"
+    "querystring": "^0.2.0",
+    "remark-parse": "^4.0.0",
+    "unified": "^6.1.5",
+    "unist-util-position": "^3.0.0",
+    "vfile": "^2.2.0"
   },
   "devDependencies": {
     "ava": "^0.23.0"

--- a/src/checkers/community.js
+++ b/src/checkers/community.js
@@ -1,6 +1,11 @@
 const btoa = require('btoa')
 const fs = require('mz/fs')
 const path = require('path')
+const vfile = require('vfile')
+const unified = require('unified')
+const parse = require('remark-parse')
+const position = require('unist-util-position')
+const range = require('mdast-util-heading-range')
 const {bunchFiles} = require('../../lib/githubHelpers.js')
 
 module.exports = async function wrap (github, opts) {
@@ -33,7 +38,22 @@ TODO This needs to be filled out!`)
       if (file.name === 'contributing' && opts.contributing) {
         fileContent = await fs.readFileSync(path.join(__dirname, '../../', opts.contributing)).toString('utf8')
       } else {
-        fileContent = await fs.readFileSync(path.join(__dirname, `../../fixtures/${file.filePath}`)).toString('utf8')
+        // Get the readme.
+        // TODO: should this be branch specific?
+        const {data: readme} = await github.get(`/repos/${github.repoName}/readme`)
+        const vf = vfile(Buffer.from(readme.content, 'base64').toString('utf8'))
+        let contributing
+
+        // Use the section from the readme, if there is one.
+        const processor = unified().use(parse).use(find('contribute', {includeHeading: true}, function (section) {
+          contributing = section
+        }))
+
+        // Parse and process the readme
+        processor.runSync(processor.parse(vf), vf)
+
+        // Use the found section, or the default fixture
+        fileContent = contributing || await fs.readFileSync(path.join(__dirname, `../../fixtures/${file.filePath}`)).toString('utf8')
       }
 
       // Text Replacements
@@ -96,4 +116,39 @@ async function community (github, opts) {
   }))
 
   return toCheck
+}
+
+function find (heading, opts, callback) {
+  if (callback === undefined) {
+    callback = opts
+    opts = undefined
+  }
+
+  return attacher
+
+  function attacher () {
+    return transformer
+  }
+
+  function transformer (tree, file) {
+    var found = false
+
+    range(tree, heading, onfind)
+
+    if (!found) {
+      callback()
+    }
+
+    function onfind (start, nodes) {
+      var heading = (opts || {}).includeHeading === true
+      var begin = heading ? start : nodes[0]
+      var initial = position.start(begin).offset
+      var final = position.end(nodes[nodes.length - 1]).offset
+
+      if (initial !== undefined && final !== undefined) {
+        found = true
+        callback(file.contents.slice(initial, final))
+      }
+    }
+  }
 }

--- a/src/utilities/find-section.js
+++ b/src/utilities/find-section.js
@@ -1,0 +1,43 @@
+const position = require('unist-util-position')
+const range = require('mdast-util-heading-range')
+
+module.exports = find
+
+function find (heading, opts, callback) {
+  if (callback === undefined) {
+    callback = opts
+    opts = undefined
+  }
+
+  return attacher
+
+  function attacher () {
+    return transformer
+  }
+
+  function transformer (tree, file) {
+    var found = false
+
+    /* Search for `heading`, call `onfind` if found. */
+    range(tree, heading, onfind)
+
+    /* Call `callback` if not found. */
+    if (!found) {
+      callback()
+    }
+
+    function onfind (start, nodes) {
+      /* Include the heading if given `includeHeading`. */
+      var heading = (opts || {}).includeHeading === true
+      var begin = heading ? start : nodes[0]
+      var initial = position.start(begin).offset
+      var final = position.end(nodes[nodes.length - 1]).offset
+
+      /* If there’s content, call `callback` with the doc. */
+      if (initial !== undefined && final !== undefined) {
+        found = true
+        callback(file.toString('utf8').slice(initial, final))
+      }
+    }
+  }
+}

--- a/src/utilities/get-section.js
+++ b/src/utilities/get-section.js
@@ -1,0 +1,25 @@
+const vfile = require('vfile')
+const unified = require('unified')
+const parse = require('remark-parse')
+const find = require('./find-section')
+
+module.exports = getSection
+
+function getSection (buf, title) {
+  const file = vfile(buf)
+  let section
+
+  // Use the section from the readme, if there is one.
+  const processor = unified()
+    .use(parse)
+    .use(find(title, {includeHeading: true}, found))
+
+  // Parse and process the readme
+  processor.runSync(processor.parse(file), file)
+
+  return section
+
+  function found (doc) {
+    section = doc
+  }
+}

--- a/test/fixtures/readme-with-contributing.md
+++ b/test/fixtures/readme-with-contributing.md
@@ -1,0 +1,11 @@
+# Some title
+
+> Some description
+
+## Contribute
+
+Some longer description.
+
+## License
+
+MIT © Richard McRichface

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,85 @@
 const test = require('ava').test
 const fs = require('fs')
 const path = require('path')
+const vfile = require('vfile')
+const unified = require('unified')
+const parse = require('remark-parse')
+const getSection = require('../src/utilities/get-section')
+const findSection = require('../src/utilities/find-section')
 
-// TODO Make a more useful test. This literally just tests .replace on fs.
-test('replaces email in code of conduct', async t => {
-  const replacedFile = await fs.readFileSync(path.join(__dirname, `../fixtures/CODE_OF_CONDUCT.md`))
-    .toString('utf8')
-    .replace('[INSERT EMAIL ADDRESS]', 'test@example.com')
+test('utilities/find-section', t => {
+  const buf = fs.readFileSync(path.join(__dirname, 'fixtures', 'readme-with-contributing.md'))
 
-  const expectedFile = await fs.readFileSync(path.join(__dirname, `fixtures/CODE_OF_CONDUCT.md`))
-      .toString('utf8')
+  t.is(
+    getSection(buf, 'missing'),
+    undefined,
+    'should return `undefined` if a section is missing'
+  )
 
-  t.is(replacedFile, expectedFile)
+  t.is(
+    getSection(buf, 'contribute'),
+    [
+      '## Contribute',
+      '',
+      'Some longer description.'
+    ].join('\n'),
+    'should find a section in a buffer'
+  )
+
+  t.is(
+    getSection(buf, 'license'),
+    [
+      '## License',
+      '',
+      'MIT © Richard McRichface'
+    ].join('\n'),
+    'should find other sections'
+  )
+
+  t.is(
+    getSection(String(buf), 'contribute'),
+    [
+      '## Contribute',
+      '',
+      'Some longer description.'
+    ].join('\n'),
+    'should find a section in a string'
+  )
+})
+
+test('utilities/find-section', t => {
+  const filePath = path.join(__dirname, 'fixtures', 'readme-with-contributing.md')
+  const buf = fs.readFileSync(filePath)
+  const file = vfile({path: filePath, contents: buf})
+  const tree = unified().use(parse).parse(file)
+
+  t.plan(3)
+
+  findSection('missing', function (section) {
+    t.is(
+      section,
+      undefined,
+      'should invoke with `undefined` if a section is missing'
+    )
+  })()(tree, file)
+
+  findSection('contribute', function (section) {
+    t.is(
+      section,
+      'Some longer description.',
+      'should find a section'
+    )
+  })()(tree, file)
+
+  findSection('contribute', {includeHeading: true}, function (section) {
+    t.is(
+      section,
+      [
+        '## Contribute',
+        '',
+        'Some longer description.'
+      ].join('\n'),
+      'should include the heading if given `includeHeading: true`'
+    )
+  })()(tree, file)
 })


### PR DESCRIPTION
Previously, if there was no `CONTRIBUTE.md` file, the fixture in this repo was used.  Now, in this case, and if there’s a `Contribute` section on the README of the repository, that section (including the heading) is used instead as a template for `CONTRIBUTE.md`.

Related to GH-12.
Supersedes GH-22.